### PR TITLE
Install WUSA/KBs via WinRM

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,12 @@ In this case your `what_will_be_installed.txt` will look like:
   WIN-H7VQ4... ------ KB2961851  15 MB Security Update for Internet Explorer 11...
   WIN-H7VQ4... ------ KB2934520  72 MB Microsoft .NET Framework 4.5.2 for Windo...
 ```
+
+Install an update from within a WinRM remote session. Because wusa.exe cannot be used over WinRM directly, and `Invoke-WUInstall.ps1` works around this by scheduling a task to actually install the update.
+
+```puppet
+  windows_updates::invoke_remote {'Some cool KB!':
+    ensure => 'present',
+    kb => 'KB3012199'
+  }
+```

--- a/manifests/invoke_remote.pp
+++ b/manifests/invoke_remote.pp
@@ -1,0 +1,20 @@
+define windows_updates::invoke_remote (
+  $ensure   = 'enabled',
+  $kb = undef
+){
+  require windows_updates
+
+  case $ensure {
+    'enabled', 'present': {
+      exec { "Install ${kb}":
+        command  => template('windows_updates/invoke_remote.ps1.erb'),
+        creates  => "C:\\ProgramData\\InstalledUpdates\\${kb}.flg",
+        provider => 'powershell',
+        timeout  => 1800
+      }
+    }
+    default: {
+      fail('Invalid ensure option!\n')
+    }
+  }
+}

--- a/templates/invoke_remote.ps1.erb
+++ b/templates/invoke_remote.ps1.erb
@@ -1,0 +1,5 @@
+Invoke-WUInstall -ScriptBlock {
+  Import-Module "PSWindowsUpdate"
+  Get-WUInstall -KBArticleID "<%= @kb %>" -AcceptAll -AutoReboot | Out-File C:\PSWindowsUpdate.log
+  Set-Content "C:\ProgramData\InstalledUpdates\<%= @kb %>.flg" "Installed"
+}


### PR DESCRIPTION
WinRM restricts calling wusa.exe to install MSUs directly.

Use the `Invoke-WUInstall` PSWindowsUpdate cmdlet to enable this scenario.

I've tried this out successfully against a Windows 2012r2 GCE instance over WinRM.

Fixes #5.