### PR TITLE
add winrm support to install_kb task

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,5 @@ Install an update from within a WinRM remote session. Because wusa.exe cannot be
     kb => 'KB3012199'
   }
 ```
+
+Alternatively, you can use the the `windows_updates::install_kb` task, which auto-detects when it's running over WinRM and switches to task scheduling to still be able to install the update. For this to work inside of Puppet Enterprise, you need to be running at least PE 2019.0 or higher. If you're on an older version of PE and want to use this task, use Bolt instead.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "noma4i-windows_updates",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "noma4i",
   "summary": "Manage Windows Updates by KBArticleID or Name exact/partial match",
   "license": "Apache-2.0",

--- a/tasks/install_kb.json
+++ b/tasks/install_kb.json
@@ -1,6 +1,10 @@
 {
   "description": "Immediately installs a specific KB update",
   "input_method": "powershell",
+  "files": [
+    "windows_updates/files/",
+    "windows_updates/lib/windows_updates/errorcodes.txt"
+  ],
   "parameters": {
     "kb": {
       "description": "The KB number of the patch you want to install (e.g. KB123456)",

--- a/tasks/install_kb.ps1
+++ b/tasks/install_kb.ps1
@@ -1,40 +1,124 @@
 [CmdletBinding()]
 Param(
-  [Parameter(Mandatory = $True)] [String]  $kb,
-  [Parameter(Mandatory = $True)] [Boolean] $restart
+    [Parameter(Mandatory = $True)] [String]  $kb,
+    [Parameter(Mandatory = $True)] [Boolean] $restart,
+    [Parameter(Mandatory = $True)] [String]  $_installdir
 )
 
+$Trackingpath = "$Env:ProgramData\InstalledUpdates"
 $ProgressPreference = 'SilentlyContinue'
-$LibDir = "$env:ProgramData\PuppetLabs\puppet\cache\lib\windows_updates"
-$LibDir += "\errorcodes.txt"
-$all_error_codes = Get-Content -raw -Path $LibDir | ConvertFrom-StringData
+$ErrCodesFile = "$_installdir/windows_updates/lib/windows_updates/errorcodes.txt"
+$all_error_codes = Get-Content -raw -Path $ErrCodesFile | ConvertFrom-StringData
 
-[void](Install-WindowsUpdate -KBArticleID "$KB" -AcceptAll -IgnoreReboot)
-Start-Sleep 5
-$update = Get-WUHistory | ? KB -eq $KB | Sort-Object Date -Descending | Select-Object -First 1
+if (!(Test-Path -Path $Trackingpath)){
+    New-Item -ItemType directory -Path $Trackingpath -Force | Out-Null
+}
+
+if ((Get-Content "$Trackingpath\$KB.flg" -ErrorAction SilentlyContinue) -eq "Installed") {
+    Write-Host "Update $KB is already installed, skipping installation..."
+    Exit 0
+}
+
+Import-Module -Name "$_installdir/windows_updates/files/PSWindowsUpdate"
+if (Get-WindowsUpdate -KBArticleID "$KB") {
+    Write-Host "Update $KB is available on the update server, proceeding with installation..."
+} Else {
+    Write-Host "Update $KB is not provided by the update server!"
+    Exit 5
+}
+
+if ($PSSenderInfo){
+    # We are running in a WinRM session, can't install Windows Updates directly
+    $User = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $Role = (New-Object Security.Principal.WindowsPrincipal $user).IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
+    if (!$Role){
+        Write-Host "To install updates, the account used to connect over WinRM must have administrative permissions."
+        Exit 1
+    }
+    Write-Host "Running via WinRM: Creating scheduled task to install update $kb"
+    [String]$TaskName = "PSWindowsUpdate"
+    [String]$Script = "Import-Module -Name '$_installdir/windows_updates/files/PSWindowsUpdate'; Get-WindowsUpdate -KBArticleID '$KB' -Install -AcceptAll -IgnoreReboot"
+  
+    $Scheduler = New-Object -ComObject Schedule.Service
+    $Task = $Scheduler.NewTask(0)
+  
+    $RegistrationInfo = $Task.RegistrationInfo
+    $RegistrationInfo.Description = $TaskName
+    $RegistrationInfo.Author = $User.Name
+  
+    $Settings = $Task.Settings
+    $Settings.Enabled = $True
+    $Settings.StartWhenAvailable = $True
+    $Settings.Hidden = $False
+  
+    $Action = $Task.Actions.Create(0)
+    $Action.Path = "powershell"
+    $Action.Arguments = "-Command ""$Script"""
+    
+    $Task.Principal.RunLevel = 1
+  
+    $Scheduler.Connect('localhost')
+    $RootFolder = $Scheduler.GetFolder("\")
+    if ($Scheduler.GetRunningTasks(0) | Where-Object {$_.Name -eq $TaskName}) {
+        Write-Host "A PSWindowsUpdate scheduled task is already running, aborting creation of new scheduled task to install $KB"
+        Exit 1
+    }
+    $RootFolder.RegisterTaskDefinition($TaskName, $Task, 6, "SYSTEM", $Null, 1) | Out-Null
+    $RootFolder.GetTask($TaskName).Run(0) | Out-Null
+    
+    $timeout = 14400 # seconds
+    $timer =  [Diagnostics.Stopwatch]::StartNew()
+    Write-Host "Waiting on PSWindowsUpdate scheduled task to complete..."
+    while (($RootFolder.GetTask($TaskName).State -ne 3) -and ($timer.Elapsed.TotalSeconds -lt $timeout)) {    
+        Start-Sleep -Seconds 10
+    }
+    $timer.Stop()
+    if ($RootFolder.GetTask($TaskName).State -eq 3) {
+        if ($RootFolder.GetTask($TaskName).LastTaskResult -eq 0) {
+            Write-Host "Installation of $KB took $([int]$timer.Elapsed.TotalSeconds) seconds"
+            $RootFolder.DeleteTask($TaskName,0)
+        } Else {
+            Write-Host "Installation of $KB seems to have failed, the scheduled task exited with errorcode $($RootFolder.GetTask($TaskName).LastTaskResult)"
+            $RootFolder.DeleteTask($TaskName,0)
+            Exit 1
+        }
+    } Else {
+        Write-Host "Timeout waiting for PSWindowsUpdate scheduled task to complete. The task will keep running in the background, please check it manually."
+        Exit 0
+    }
+} Else {
+    # Not running in a WinRM session, we can install Windows Updates directly
+    Get-WindowsUpdate -KBArticleID "$KB" -Install -AcceptAll -IgnoreReboot
+    Start-Sleep 10
+}
+
+$update = Get-WUHistory | Where-Object KB -eq $KB | Sort-Object Date -Descending | Select-Object -First 1
 switch -regex ($update.Result) {
     'Succeeded' {
-        Set-Content "C:\ProgramData\InstalledUpdates\$KB.flg" "Installed"
+        Set-Content "$Trackingpath\$KB.flg" "Installed"
         if ($restart) {
-            Write-Output "Restart parameter enabled, restarting node in 30 seconds"
+            Write-Host "Restart parameter enabled, restarting node in 30 seconds"
             & shutdown -r -t 30
         }
     }
     'SucceededWithErrors|InProgress' {
         $HResult = [Convert]::ToString($update.HResult, 16)
         $Message = $all_error_codes["0x$HResult"]
-        Write-Output "Update $KB was installed but reported (likely reboot needed): $Message"
-        Set-Content "C:\ProgramData\InstalledUpdates\$KB.flg" "Installed"
+        Write-Host "Update $KB was installed but reported (likely reboot needed): $Message"
+        Set-Content "$Trackingpath\$KB.flg" "Installed"
         if ($restart) {
-            Write-Output "Restart parameter enabled, restarting node in 30 seconds"
+            Write-Host "Restart parameter enabled, restarting node in 30 seconds"
             & shutdown -r -t 30
         }
     }
     'Failed' {
         $HResult = [Convert]::ToString($update.HResult, 16)
         $Message = $all_error_codes["0x$HResult"]
-        Write-Output "Update $KB failed to install, reporting: $Message"
+        Write-Host "Update $KB failed to install, reporting: $Message"
         Exit 2
     }
-    default { Write-Output "Update $KB is not provided by the update server!"; Exit 5 }
+    default {
+        Write-Host "Could not find update $KB in the Windows Update History, it seems installation has not succeeded!"
+        Exit 5
+    }
 }

--- a/templates/install_by_title.ps1.erb
+++ b/templates/install_by_title.ps1.erb
@@ -7,7 +7,7 @@ Get-WindowsUpdate -Title "<%= @name_mask %>" | foreach {
     if ((Test-Path "c:\ProgramData\InstalledUpdates\$($_.KB).flg") -eq $False) {
         [void](Install-WindowsUpdate -KBArticleID "$($_.KB)" -AcceptAll -IgnoreReboot)
         Start-Sleep 5
-        $update = Get-WUHistory | ? KB -eq <%= @kb %> | Sort-Object Date -Descending | Select-Object -First 1
+        $update = Get-WUHistory -Last 500 | ? KB -eq <%= @kb %> | Sort-Object Date -Descending | Select-Object -First 1
         switch -regex ($update.Result) {
             'Succeeded' { Set-Content "C:\ProgramData\InstalledUpdates\<%= @kb %>.flg" "Installed" }
             'SucceededWithErrors|InProgress' {

--- a/templates/install_kb.ps1.erb
+++ b/templates/install_kb.ps1.erb
@@ -5,7 +5,7 @@ $all_error_codes = Get-Content -raw -Path $LibDir | ConvertFrom-StringData
 
 [void](Install-WindowsUpdate -KBArticleID "<%= @kb %>" -AcceptAll -IgnoreReboot)
 Start-Sleep 5
-$update = Get-WUHistory | ? KB -eq <%= @kb %> | Sort-Object Date -Descending | Select-Object -First 1
+$update = Get-WUHistory -Last 500 | ? KB -eq <%= @kb %> | Sort-Object Date -Descending | Select-Object -First 1
 switch -regex ($update.Result) {
     'Succeeded' { Set-Content "C:\ProgramData\InstalledUpdates\<%= @kb %>.flg" "Installed" }
     'SucceededWithErrors|InProgress' {

--- a/templates/invoke_remote.ps1.erb
+++ b/templates/invoke_remote.ps1.erb
@@ -3,7 +3,7 @@ Invoke-WUInstall -Script {
     $ProgressPreference = 'SilentlyContinue'
     Install-WindowsUpdate -KBArticleID "<%= @kb %>" -AcceptAll -IgnoreReboot | Out-File C:\PSWindowsUpdate.log
     Start-Sleep 5
-    $update = Get-WUHistory | ? KB -eq <%= @kb %> | Sort-Object Date -Descending | Select-Object -First 1
+    $update = Get-WUHistory -Last 500 | ? KB -eq <%= @kb %> | Sort-Object Date -Descending | Select-Object -First 1
     switch -regex ($update.Result) {
         'Succeeded' { Set-Content "C:\ProgramData\InstalledUpdates\<%= @kb %>.flg" "Installed" }
         'SucceededWithErrors|InProgress' {


### PR DESCRIPTION
This PR adds WinRM support to the `windows_updates::install_kb` task. This enables this task to also be used in Puppet Bolt and Puppet Remediate.

The updates task auto-detects if it's running over PCP or WinRM and then uses the right method to install the patch. Since installing updates via WinRM directly is not allowed by the Windows Update API, the task will leverage a scheduled task to install the update when it detects it's running over WinRM.